### PR TITLE
Use `method.receiver.class.service_name` instead of `method.owner.service_name`

### DIFF
--- a/lib/grpc_access_logging_interceptor/server_interceptor.rb
+++ b/lib/grpc_access_logging_interceptor/server_interceptor.rb
@@ -70,7 +70,7 @@ module GrpcAccessLoggingInterceptor
       # We use path, which is represented as "/" Service-Name "/" {method name}
       # e.g. /google.pubsub.v2.PublisherService/CreateTopic.
       # cf. https://github.com/grpc/grpc/blob/v1.24.0/doc/PROTOCOL-HTTP2.md
-      "/#{method.owner.service_name}/#{camelize(method.name.to_s)}"
+      "/#{method.receiver.class.service_name}/#{camelize(method.name.to_s)}"
     end
 
     # @param [String] term


### PR DESCRIPTION
## Why

Although `method.owner` returns the receiver class in most cases, it does not work if the method was overridden
by some prepended modules.

## What

Replace `method.owner.service_name` with `method.receiver.class.service_name`. The former returns the service
name even though the method is overwritten.