### PR TITLE
Bump up version to v0.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grpc_access_logging_interceptor (0.0.5)
+    grpc_access_logging_interceptor (0.0.6)
       gmsc
       grpc
 
@@ -12,10 +12,10 @@ GEM
     diff-lcs (1.3)
     gmsc (0.0.1)
     google-protobuf (3.11.1)
-    googleapis-common-protos-types (1.0.4)
-      google-protobuf (~> 3.0)
-    grpc (1.25.0)
-      google-protobuf (~> 3.8)
+    googleapis-common-protos-types (1.0.5)
+      google-protobuf (~> 3.11)
+    grpc (1.28.0)
+      google-protobuf (~> 3.11)
       googleapis-common-protos-types (~> 1.0)
     method_source (0.9.2)
     pry (0.12.2)
@@ -55,4 +55,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/lib/grpc_access_logging_interceptor/version.rb
+++ b/lib/grpc_access_logging_interceptor/version.rb
@@ -1,3 +1,3 @@
 module GrpcAccessLoggingInterceptor
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
## Why

I would like to apply the modification https://github.com/wantedly/grpc_access_logging_interceptor/pull/9 in wantedly/servicex-ruby.

## What

Release the version v0.0.6